### PR TITLE
Add and setup listings package

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -26,3 +26,23 @@
      pdfauthor=\PDFAUTHOR,
      pdfkeywords=\PDFKEYWORDS]{hyperref}
 \usepackage{pxjahyper} % for japanese encoding on pdf bookmarks
+\usepackage{listings}
+
+\lstset{
+  breaklines = true,
+  basicstyle=\ttfamily,
+  commentstyle={\itshape \color[cmyk]{1,0.4,1,0}},
+  classoffset=1,
+  %% keywordstyle={\bfseries \color[cmyk]{0,1,0,0}},
+  %% stringstyle={\ttfamily \color[rgb]{0,0,1}},
+  showstringspaces=false,
+  columns=fullflexible,
+  keepspaces=true,
+  escapeinside={<@}{@>},
+  %% frame=tRBl,
+  framesep=5pt,
+  %% numbers=left,
+  stepnumber=1,
+  numberstyle=\tiny,
+  tabsize=2,
+}


### PR DESCRIPTION
Setting up for `lstlisting` command, which allows to have mathescape and provides more flexible formatting control than the `verbatim` environment suggested on sample code.

(am setting the listing package to produce output similar to the verbatim one)